### PR TITLE
Update Slack location

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Table of contents:
 * [Quora](https://www.quora.com/topic/Symfony) - Symfony topics on Quora.
 * [Reddit](https://www.reddit.com/r/symfony) - Ask and answer questions, discussion.
 * [SensioLabs Connect](https://connect.sensiolabs.com/login) - Developer social network, earn achievements for your community involvement and commitment.
-* [Slack](https://symfony2slack.herokuapp.com/) - Symfony group on Slack, platform for team communication.
+* [Slack](https://symfony.com/slack-invite) - Symfony on Slack, platform for team communication.
 * [Stack Overflow](http://stackoverflow.com/questions/tagged/symfony2) - Symfony support on Stack Overflow.
 * [Twitter](https://twitter.com/symfony) - Keep up with Symfony news in a twitter-like way.
 


### PR DESCRIPTION
New official Slack location for Symfony is available via invites here:
https://symfony.com/slack-invite

This patch updates the previous non-working Heroku application location.

* https://twitter.com/fabpot/status/809305771238420480

Thank you for considering merging it.